### PR TITLE
refactor: melhorar a clareza do Dockerfile com ajustes nas variáveis …

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,17 +1,34 @@
+# syntax=docker/dockerfile:1
+
 # Use the official MySQL 5.7 image as the base image
 FROM mysql:5.7
 
-# Set the root password for MySQL
-ENV MYSQL_ROOT_PASSWORD=root
-ENV MYSQL_DATABASE=database
-ENV MYSQL_USER=user
-ENV MYSQL_PASSWORD=password
+# Labels for better image metadata
+LABEL maintainer="marcelobuzzetti@gmail.com" \
+      description="MySQL 5.7 database for Controle application" \
+      version="1.0"
 
-# Copy the SQL script to initialize the database
-COPY controle.sql /docker-entrypoint-initdb.d/
+# Environment variables - should be overridden at runtime for security
+ENV MYSQL_ROOT_PASSWORD=root \
+    MYSQL_DATABASE=database \
+    MYSQL_USER=user \
+    MYSQL_PASSWORD=password
 
-ADD charset.cnf /etc/mysql/conf.d/
-RUN chmod 644 /etc/mysql/conf.d/charset.cnf
+# Copy configuration and initialization files
+# Using COPY instead of ADD for better clarity
+COPY charset.cnf /etc/mysql/conf.d/charset.cnf
+COPY controle.sql /docker-entrypoint-initdb.d/controle.sql
+
+# Set proper permissions in a single RUN command to reduce layers
+RUN chmod 644 /etc/mysql/conf.d/charset.cnf && \
+    chmod 644 /docker-entrypoint-initdb.d/controle.sql
 
 # Expose the default MySQL port
 EXPOSE 3306
+
+# Health check to ensure MySQL is responding
+HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
+    CMD mysqladmin ping -h localhost -u root -p${MYSQL_ROOT_PASSWORD} || exit 1
+
+# Use the default entrypoint and cmd from the base image
+# CMD ["mysqld"]


### PR DESCRIPTION
This pull request refactors the `mysql/Dockerfile` to improve maintainability, security, and image metadata. The changes include better labeling, improved file copying practices, consolidated permission setting, and the addition of a health check to ensure the MySQL service is running.

**Dockerfile improvements:**

* Added descriptive `LABEL` metadata for maintainer, description, and version to the image.
* Consolidated environment variable definitions for MySQL configuration into a single `ENV` statement, with a note that they should be overridden at runtime for security.

**File handling and permissions:**

* Switched from `ADD` to `COPY` for configuration and initialization files for clarity, and set file permissions in a single `RUN` command to reduce image layers.

**Operational enhancements:**

* Added a `HEALTHCHECK` instruction to monitor MySQL responsiveness, improving container reliability.…de ambiente e permissões